### PR TITLE
fix recipies

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -132,7 +132,7 @@ core.register_craft({
 core.register_craft({
 	output = 'advtrains:rocket_wagon_tender',
 	recipe = {
-		{'', '', 'advtrains_train_rocket:barrel'},
+		{'', '', 'advtrains_train_rocket:barrel_stack'},
 		{'group:wood', 'group:wood', 'group:wood'},
 		{'advtrains:wheel', '', 'advtrains:wheel'},
 	},
@@ -141,7 +141,7 @@ core.register_craft({
 core.register_craft({
 	output = 'advtrains:rocket_wagon_tender',
 	recipe = {
-		{'advtrains_train_rocket:barrel_stack', 'advtrains_train_rocket:barrel_stack', 'advtrains_train_rocket:barrel_stack'},
+		{'advtrains_train_rocket:barrel', 'advtrains_train_rocket:barrel', 'advtrains_train_rocket:barrel'},
 		{'group:wood', 'group:wood', 'group:wood'},
 		{'advtrains:wheel', '', 'advtrains:wheel'},
 	},


### PR DESCRIPTION
rocket wagon tender was craftable with recipies using either one barrel or three barrel stacks. As barrel stacks are craftable from three barrels, it seems sensible to change them it to be either craftable with three barrels or one barrel stack instead.